### PR TITLE
Fix: Synchronous upload on file component crashes for already uploaded files

### DIFF
--- a/shesha-reactjs/src/components/reactTable/styles/styles.ts
+++ b/shesha-reactjs/src/components/reactTable/styles/styles.ts
@@ -575,6 +575,20 @@ export const useMainStyles = createStyles(({ css, cx, token, prefixCls, iconPref
             background: ${rowSelectedBackgroundColor || token.colorPrimary} !important;
             color: white;
 
+            /* Target text elements while preserving semantic colors for validation states */
+            td, th, span:not(.ant-form-item-feedback-icon):not(.ant-form-item-explain *):not(.error):not(.warning):not(.ant-alert *),
+            div:not(.ant-form-item-explain):not(.error):not(.warning):not(.ant-alert),
+            p, label, button, a {
+              color: white !important;
+            }
+
+            /* Icons should be white */
+            .${iconPrefixCls},
+            .${iconPrefixCls} svg {
+              color: white !important;
+              fill: white !important;
+            }
+
             .ant-form-item-control-input-content, button, a {
                     color: white;
               }


### PR DESCRIPTION
Resolves #3853

## Summary
Fixed redundant condition in `/Users/jamesbaloyi/Projects/shesha-framework/shesha-reactjs/src/providers/storedFile/index.tsx` by removing the unnecessary `uploadMode === 'sync'` check after the async early return, simplifying the logic to just check `if (newFileId)`. Enhanced `/Users/jamesbaloyi/Projects/shesha-framework/shesha-reactjs/src/components/reactTable/styles/styles.ts` by replacing broad selectors with targeted ones (td, th, span, div, p, label, button, a) that explicitly exclude semantic validation/error classes (.ant-form-item-feedback-icon, .ant-form-item-explain, .error, .warning, .ant-alert) and added icon-specific selectors using iconPrefixCls to ensure proper white text rendering in selected rows while preserving error/warning state colors.

## Files Changed
- `/Users/jamesbaloyi/Projects/shesha-framework/shesha-reactjs/src/components/reactTable/styles/styles.ts`
- `/Users/jamesbaloyi/Projects/shesha-framework/shesha-reactjs/src/providers/storedFile/index.tsx`