### PR TITLE
Fix: Properties Panel Issues

### DIFF
--- a/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/searchableTabsComponent.tsx
@@ -18,6 +18,7 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const [activeTabKey, setActiveTabKey] = useState('1');
   const searchRefs = useRef(new Map());
+  const userInitiatedTabChange = useRef(false);
   const { styles } = useStyles();
 
   const formState = useFormState(false);
@@ -49,6 +50,7 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
         className={options?.className}
         style={options?.style}
         autoFocus={options?.autoFocus}
+        tabIndex={0}
       />
     );
 
@@ -70,6 +72,7 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
   }, [activeTabKey]);
 
   const handleTabChange = (newActiveKey: string): void => {
+    userInitiatedTabChange.current = true;
     setActiveTabKey(newActiveKey);
   };
 
@@ -80,9 +83,14 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
     }
   }, [searchQuery, focusActiveTabSearch]);
 
-  // Focus search input when tab changes
+  // Focus search input when tab changes (but not for user-initiated tab changes)
   useEffect(() => {
-    focusActiveTabSearch();
+    if (!userInitiatedTabChange.current) {
+      focusActiveTabSearch();
+    } else {
+      // Reset the flag after processing
+      userInitiatedTabChange.current = false;
+    }
   }, [activeTabKey, focusActiveTabSearch]);
 
   const isComponentHidden = (component): boolean => {
@@ -174,7 +182,7 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
 
 
   return (
-    <>
+    <div className={styles.container}>
       {newFilteredTabs.length === 0 &&
         renderSearchInput({
           autoFocus: true,
@@ -192,7 +200,7 @@ const SearchableTabs: React.FC<SearchableTabsProps> = ({ model }) => {
             className={styles.content}
           />
         )}
-    </>
+    </div>
   );
 };
 

--- a/shesha-reactjs/src/designer-components/propertiesTabs/style.ts
+++ b/shesha-reactjs/src/designer-components/propertiesTabs/style.ts
@@ -9,6 +9,11 @@ export const useStyles = createStyles(({ css, cx, token }) => {
     }
   `);
 
+  const container = cx(css`
+    container-type: inline-size;
+    width: 100%;
+  `);
+
   const content = cx(css`
     .ant-tabs-tab, .ant-tabs-nav-operations {
       height: 30px;
@@ -17,8 +22,10 @@ export const useStyles = createStyles(({ css, cx, token }) => {
       --ant-tabs-card-padding-sm: 0 8px;
     }
 
-    .ant-form-item-vertical .ant-form-item-row {
-      flex-direction: row !important;
+    @container (min-width: 800px) {
+      .ant-form-item-vertical .ant-form-item-row {
+        flex-direction: row !important;
+      }
     }
 
     .sha-toolbar-btn-configurable, .ant-btn {
@@ -45,6 +52,7 @@ export const useStyles = createStyles(({ css, cx, token }) => {
 
   return {
     searchField,
+    container,
     content,
   };
 });


### PR DESCRIPTION
Resolves #4464

## Summary
Fixed two issues in the properties panel: (1) Tab navigation becoming disabled after using the search bar - modified `src/designer-components/propertiesTabs/searchableTabsComponent.tsx` to add a `userInitiatedTabChange` ref that prevents auto-focusing the search input when users manually switch tabs, allowing normal keyboard/mouse tab navigation to work; (2) Incorrect layout breakpoint - modified `src/designer-components/propertiesTabs/style.ts` to wrap the inline layout CSS rule in a `@container (min-width: 800px)` query and added `container-type: inline-size` to enable container-based responsive behavior, ensuring properties display stacked below 800px and inline at 800px+ instead of always inline.

## Files Changed
- `src/designer-components/propertiesTabs/searchableTabsComponent.tsx`
- `src/designer-components/propertiesTabs/style.ts`